### PR TITLE
Concise installation, fixes virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ A Minecraft: PE server in Python
 ## Installation
 It's easy, make sure you've got Python 3.5 installed, then,
 ```sh
-$ pip install virtualenv
-$ virtualenv .venv
+$ pip install virtualenv  ## Optional, may also be installed via source or Linux repository
 $ virtualenv -p /usr/bin/python .venv
 $ virtualenv -p /usr/bin/python2.7 .venv
 $ source ./venv/bin/activate


### PR DESCRIPTION
### Description
Changed wording on the installation and removed a redundant command

### Reason to modify
`virtualenv .venv` was redundant and produced "Too many .. Links" error for commands following.